### PR TITLE
Lightly validate custom data formats

### DIFF
--- a/.github/workflows/vectorlint.yml
+++ b/.github/workflows/vectorlint.yml
@@ -1,0 +1,27 @@
+name: Vector Lint
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '15 */12 * * *'
+
+jobs:
+  build:
+    name: Lint vectors/schemas
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Format
+        run: go fmt ./...
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Run vectorlint
+        run: ./vectorlint

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/c2sp/wycheproof
+
+go 1.23.6
+
+require (
+	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/santhosh-tekuri/jsonschema v1.2.4 h1:hNhW8e7t+H1vgY+1QeEQpveR6D4+OwKPXCfD2aieJis=
+github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/schemas/ecdh_pem_test_schema_v1.json
+++ b/schemas/ecdh_pem_test_schema_v1.json
@@ -1,0 +1,101 @@
+{
+  "type": "object",
+  "definitions": {
+    "EcdhPemTestGroup": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "EcdhPemTest"
+          ]
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EcdhPemTestVector"
+          }
+        }
+      }
+    },
+    "EcdhPemTestVector": {
+      "type": "object",
+      "properties": {
+        "tcId": {
+          "type": "integer",
+          "description": "Identifier of the test case"
+        },
+        "comment": {
+          "type": "string",
+          "description": "A brief description of the test case"
+        },
+        "public": {
+          "type": "string",
+          "format": "Pem",
+          "description": "Pem encoded public key"
+        },
+        "private": {
+          "type": "string",
+          "format": "Pem",
+          "description": "Pem encoded private key"
+        },
+        "shared": {
+          "type": "string",
+          "format": "HexBytes",
+          "description": "The shared secret key"
+        },
+        "result": {
+          "type": "string",
+          "description": "Test result",
+          "enum": [
+            "valid",
+            "invalid",
+            "acceptable"
+          ]
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of flags"
+        }
+      }
+    }
+  },
+  "properties": {
+    "algorithm": {
+      "type": "string",
+      "description": "the primitive tested in the test file"
+    },
+    "generatorVersion": {
+      "type": "string",
+      "description": "the version of the test vectors."
+    },
+    "header": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "additional documentation"
+    },
+    "notes": {
+      "type": "object",
+      "description": "a description of the labels used in the test vectors"
+    },
+    "numberOfTests": {
+      "type": "integer",
+      "description": "the number of test vectors in this test"
+    },
+    "schema": {
+      "enum": [
+        "ecdh_pem_test_schema_v1.json"
+      ]
+    },
+    "testGroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/EcdhPemTestGroup"
+      }
+    }
+  }
+}

--- a/testvectors_v1/ecdh_secp224r1_pem_test.json
+++ b/testvectors_v1/ecdh_secp224r1_pem_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDH",
-  "schema" : "ecdh_pem_test_schema.json",
+  "schema" : "ecdh_pem_test_schema_v1.json",
   "generatorVersion" : "0.9rc5",
   "numberOfTests" : 714,
   "header" : [

--- a/testvectors_v1/ecdh_secp256r1_pem_test.json
+++ b/testvectors_v1/ecdh_secp256r1_pem_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDH",
-  "schema" : "ecdh_pem_test_schema.json",
+  "schema" : "ecdh_pem_test_schema_v1.json",
   "generatorVersion" : "0.9rc5",
   "numberOfTests" : 612,
   "header" : [

--- a/testvectors_v1/ecdh_secp384r1_pem_test.json
+++ b/testvectors_v1/ecdh_secp384r1_pem_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDH",
-  "schema" : "ecdh_pem_test_schema.json",
+  "schema" : "ecdh_pem_test_schema_v1.json",
   "generatorVersion" : "0.9rc5",
   "numberOfTests" : 1047,
   "header" : [

--- a/testvectors_v1/ecdh_secp521r1_pem_test.json
+++ b/testvectors_v1/ecdh_secp521r1_pem_test.json
@@ -1,6 +1,6 @@
 {
   "algorithm" : "ECDH",
-  "schema" : "ecdh_pem_test_schema.json",
+  "schema" : "ecdh_pem_test_schema_v1.json",
   "generatorVersion" : "0.9rc5",
   "numberOfTests" : 916,
   "header" : [

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -1,0 +1,190 @@
+// vectorlint analyzes vector files to flag potential issues
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func main() {
+	schemaDirectory := flag.String("schemas-dir", "schemas", "directory containing schema files")
+	vectorsDirectories := flag.String("vectors-dir", "testvectors_v1,testvectors", "comma separated directories containing vector files")
+	vectorFilter := flag.String("vector-filter", "", "only validate vector files matching the provided pattern")
+
+	flag.Parse()
+
+	vectorDirectoryParts := strings.Split(*vectorsDirectories, ",")
+
+	log.Printf("reading schemas from %q\n", *schemaDirectory)
+	log.Printf("reading vectors from %q\n", vectorDirectoryParts)
+
+	var vectorRegex *regexp.Regexp
+	if *vectorFilter != "" {
+		vectorRegex = regexp.MustCompile(*vectorFilter)
+		log.Printf("filtering vectors with %q\n", *vectorFilter)
+	}
+
+	schemaCompiler := jsonschema.NewCompiler()
+
+	for _, f := range customFormats {
+		schemaCompiler.RegisterFormat(&f)
+	}
+
+	var total, valid, invalid, noSchema, ignored int
+	for _, vectorDir := range vectorDirectoryParts {
+		err := filepath.WalkDir(vectorDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.IsDir() || !strings.HasSuffix(d.Name(), ".json") {
+				return nil
+			}
+
+			if vectorRegex != nil && !vectorRegex.MatchString(d.Name()) {
+				return nil
+			}
+
+			vectorData, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("failed to read %s: %w", path, err)
+			}
+
+			total++
+
+			var vector struct {
+				Schema string `json:"schema"`
+			}
+
+			if err := json.Unmarshal(vectorData, &vector); err != nil {
+				log.Printf("❌ %q: invalid vector JSON data: %s\n", path, err)
+				invalid++
+				return nil
+			}
+
+			if vector.Schema == "" {
+				log.Printf("❌ %q: no schema specified\n", path)
+				noSchema++
+				return nil
+			}
+
+			if missingSchemas[vector.Schema] {
+				log.Printf("⚠️ %q: ignoring missing schema %q\n", path, vector.Schema)
+				ignored++
+				return nil
+			}
+
+			schemaPath := filepath.Join(*schemaDirectory, vector.Schema)
+			if _, err := os.Stat(schemaPath); os.IsNotExist(err) {
+				log.Printf("❌ %q: referenced schema %q not found\n", path, vector.Schema)
+				invalid++
+				return nil
+			}
+
+			schema, err := schemaCompiler.Compile(schemaPath)
+			if err != nil {
+				log.Printf("❌ %q: invalid schema %q: %s\n", path, vector.Schema, err)
+				invalid++
+				return nil
+			}
+
+			var instance any
+			_ = json.Unmarshal(vectorData, &instance)
+
+			if err := schema.Validate(instance); err != nil {
+				log.Printf("❌ %q: vector doesn't validate with schema: %s\n", path, err)
+				invalid++
+				return nil
+			}
+
+			log.Printf("✅ %q: validates with %q\n", path, vector.Schema)
+			valid++
+			return nil
+		})
+		if err != nil {
+			fmt.Printf("Error walking directory: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	log.Printf("linted %d vector files\n", total)
+	log.Printf("valid: %d\n", valid)
+	log.Printf("invalid: %d\n", invalid)
+	log.Printf("no schema: %d\n", noSchema)
+	log.Printf("ignored: %d\n", ignored)
+
+	os.Exit(invalid)
+}
+
+var (
+	// TODO(XXX): some _v1 vectors reference schema files that don't exist. Until fixed, ignore these schemas.
+	missingSchemas = map[string]bool{
+		// testvectors_v1/aes_ff1_base*_test.json:
+		"fpe_str_test_schema.json": true,
+
+		// testvectors_v1/aes_ff1_radix*_test.json:
+		"fpe_list_test_schema.json": true,
+
+		// testvectors_v1/ec_prime_order_curves_test.json:
+		"ec_curve_test_schema.json": true,
+
+		// testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
+		"ecdsa_bitcoin_verify_schema.json": true,
+
+		// testvectors_v1/pbes2_hmacsha*_aes_*_test.json:
+		"pbe_test_schema.json": true,
+
+		// testvectors_v1/pbkdf2_hmacsha*_test.json:
+		"pbkdf_test_schema.json": true,
+
+		// testvectors_v1/rsa_pss_*_sha*_mgf*_params_test.json
+		// testvectors_v1/rsa_pss_misc_params_test.json:
+		"rsassa_pss_with_parameters_verify_schema.json": true,
+	}
+
+	customFormats = []jsonschema.Format{
+		{
+			Name: "Asn",
+			// TODO(XXX): validate "Asn" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "Der",
+			// TODO(XXX): validate "Der" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "EcCurve",
+			// TODO(XXX): validate "EcCurve" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "HexBytes",
+			// TODO(XXX): validate "HexBytes" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "BigInt",
+			// TODO(XXX): validate "BigInt" format.
+			Validate: noValidateFormat,
+		},
+		{
+			Name: "Pem",
+			// TODO(XXX): validate "Pem" format.
+			Validate: noValidateFormat,
+		},
+	}
+)
+
+// noValidateFormat is a placeholder Format.Validate callback that performs no validation of the input.
+func noValidateFormat(_ any) error {
+	return nil
+}

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -156,8 +156,9 @@ var (
 	customFormats = []jsonschema.Format{
 		{
 			Name: "Asn",
-			// TODO(XXX): validate "Asn" format.
-			Validate: noValidateFormat,
+			// For ASN.1 data we can validate the format is valid hex, but to decode
+			// further we need to know the expected structure (and encoding) of the data.
+			Validate: validateHex,
 		},
 		{
 			Name: "Der",

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -161,8 +161,9 @@ var (
 		},
 		{
 			Name: "Der",
-			// TODO(XXX): validate "Der" format.
-			Validate: noValidateFormat,
+			// For DER-encoded data, we can validate the format is valid hex, but to decode
+			// further we need to know the expected structure of the data.
+			Validate: validateHex,
 		},
 		{
 			Name: "EcCurve",

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -37,6 +38,7 @@ func main() {
 	for _, f := range customFormats {
 		schemaCompiler.RegisterFormat(&f)
 	}
+	schemaCompiler.AssertFormat() // Opt in to format validation.
 
 	var total, valid, invalid, noSchema, ignored int
 	for _, vectorDir := range vectorDirectoryParts {
@@ -167,9 +169,8 @@ var (
 			Validate: noValidateFormat,
 		},
 		{
-			Name: "HexBytes",
-			// TODO(XXX): validate "HexBytes" format.
-			Validate: noValidateFormat,
+			Name:     "HexBytes",
+			Validate: validateHex,
 		},
 		{
 			Name: "BigInt",
@@ -186,5 +187,19 @@ var (
 
 // noValidateFormat is a placeholder Format.Validate callback that performs no validation of the input.
 func noValidateFormat(_ any) error {
+	return nil
+}
+
+func validateHex(value any) error {
+	strVal, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("invalid non-string HexBytes value: %v", value)
+	}
+
+	_, err := hex.DecodeString(strVal)
+	if err != nil {
+		return fmt.Errorf("invalid HexBytes value: %v: %w", value, err)
+	}
+
 	return nil
 }

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"flag"
 	"fmt"
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -178,9 +179,8 @@ var (
 			Validate: noValidateFormat,
 		},
 		{
-			Name: "Pem",
-			// TODO(XXX): validate "Pem" format.
-			Validate: noValidateFormat,
+			Name:     "Pem",
+			Validate: validatePem,
 		},
 	}
 )
@@ -201,5 +201,19 @@ func validateHex(value any) error {
 		return fmt.Errorf("invalid HexBytes value: %v: %w", value, err)
 	}
 
+	return nil
+}
+
+func validatePem(value any) error {
+	strVal, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("invalid non-string Pem value: %v", value)
+	}
+
+	_, rest := pem.Decode([]byte(strVal))
+	if len(rest) != 0 {
+		return fmt.Errorf("invalid Pem value: unexpected trailing bytes %x", rest)
+	}
+	
 	return nil
 }

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -175,8 +175,8 @@ var (
 		},
 		{
 			Name: "BigInt",
-			// TODO(XXX): validate "BigInt" format.
-			Validate: noValidateFormat,
+			// For big integers, we can validate the format is valid hex but not much else.
+			Validate: validateHex,
 		},
 		{
 			Name:     "Pem",
@@ -214,6 +214,6 @@ func validatePem(value any) error {
 	if len(rest) != 0 {
 		return fmt.Errorf("invalid Pem value: unexpected trailing bytes %x", rest)
 	}
-	
+
 	return nil
 }

--- a/tools/vectorlint/main.go
+++ b/tools/vectorlint/main.go
@@ -168,8 +168,8 @@ var (
 		},
 		{
 			Name: "EcCurve",
-			// TODO(XXX): validate "EcCurve" format.
-			Validate: noValidateFormat,
+			// TODO(XXX): Seems like the EcCurve format should be defined as an enum?
+			Validate: validateCurve,
 		},
 		{
 			Name:     "HexBytes",
@@ -218,4 +218,18 @@ func validatePem(value any) error {
 	}
 
 	return nil
+}
+
+func validateCurve(value any) error {
+	strVal, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("invalid non-string EcCurve value: %v", value)
+	}
+
+	switch strVal {
+	case "curve25519", "curve448":
+		return nil
+	default:
+		return fmt.Errorf("invalid EcCurve: unknown curve name: %v", value)
+	}
 }


### PR DESCRIPTION
Continuing from https://github.com/C2SP/wycheproof/pull/129 Best reviewed commit-by-commit.

The value in the validation process is greatly reduced by the absence of required fields, and additionalProperties being forbidden by schemas, but it's a step in the right direction (and will help ensure new contributions start off on the right footing).